### PR TITLE
Strip device model name from spaces to support NEC ROM

### DIFF
--- a/bin/ltbox/actions/region.py
+++ b/bin/ltbox/actions/region.py
@@ -60,6 +60,7 @@ def convert_region_images(
     on_log(get_string("act_info_extracted"))
 
     if device_model and not dev.skip_adb:
+        device_model = device_model.replace(" ", "")
         on_log(get_string("act_val_model").format(model=device_model))
         fingerprint_key = "com.android.build.vendor_boot.fingerprint"
         if fingerprint_key in vendor_boot_info:


### PR DESCRIPTION
NEC ROM's device name includes spaces, so flashing aborts due to naming mismatch. Stripping the spaces from device_model fixes the problem.

14:23:25 - [*] Validating firmware for model 'LAVIE Tab 9QHD1'...
14:23:25 -     > Firmware fingerprint: NEC/LAVIETab9QHD1/LAVIETab9QHD1:13/SKQ1.221119.001/S103078_251029_NEC:user/release-keys
14:23:25 - [!] ERROR: Model 'LAVIE Tab 9QHD1' NOT found in fingerprint.