### PR TITLE
fix region conversion boot chain

### DIFF
--- a/crates/ltbox-gui/src/main.rs
+++ b/crates/ltbox-gui/src/main.rs
@@ -1607,6 +1607,7 @@ impl CountryAction {
 #[derive(Debug, Clone, Default)]
 struct WorkflowConfig {
     modify_region: bool,
+    device_region: Option<DeviceRegion>,
     modify_rollback: RollbackSetting,
     wipe: bool,
     country_action: CountryAction,
@@ -2061,6 +2062,13 @@ impl DeviceRegion {
         match self {
             Self::Prc => "deviceregion_prc",
             Self::Row => "deviceregion_row",
+        }
+    }
+
+    fn to_region_target(self) -> ltbox_patch::region::RegionTarget {
+        match self {
+            Self::Prc => ltbox_patch::region::RegionTarget::Prc,
+            Self::Row => ltbox_patch::region::RegionTarget::Row,
         }
     }
 }
@@ -4702,6 +4710,7 @@ impl App {
                 if self.flash.step == 2 {
                     self.wf_config = WorkflowConfig {
                         modify_region: self.flash.target == Some(FlashTarget::OtherRegion),
+                        device_region: self.flash.device_region,
                         modify_rollback: if self.flash.target == Some(FlashTarget::OtherRegion) {
                             RollbackSetting::On
                         } else {
@@ -4912,6 +4921,7 @@ impl App {
                             );
 
                             // 4. Region conversion
+                            let mut region_pair: Option<ltbox_patch::region::RegionBootChainOutput> = None;
                             if cfg.modify_region {
                                 if has_vendor_boot && has_vbmeta {
                                     ltbox_core::live!(
@@ -4924,6 +4934,67 @@ impl App {
                                         "[Region] {}",
                                         ltbox_core::i18n::tr("live_region_ready")
                                     );
+                                    let Some(device_region) = cfg.device_region else {
+                                        return Err(
+                                            "Region conversion requested but no device region was selected"
+                                                .to_string(),
+                                        );
+                                    };
+                                    let target = device_region.to_region_target();
+                                    let output_dir =
+                                        ltbox_core::app_paths::auto_output_dir_for("region_convert");
+                                    ltbox_core::live!(
+                                        log,
+                                        "[Region] Building vendor_boot/vbmeta pair for {:?} hardware",
+                                        device_region
+                                    );
+                                    match ltbox_patch::region::build_region_converted_boot_chain(
+                                        fw_dir,
+                                        &output_dir,
+                                        target,
+                                        &ltbox_patch::region::RegionPatternSet::default(),
+                                    ) {
+                                        Ok(ltbox_patch::region::RegionBootChainBuild::Built(output)) => {
+                                            ltbox_core::live!(
+                                                log,
+                                                "[Region] {}",
+                                                ltbox_core::i18n::tr("live_region_source_target")
+                                                    .replace("{source}", &format!("{:?}", output.source_region))
+                                                    .replace("{target}", &format!("{:?}", output.target))
+                                            );
+                                            ltbox_core::live!(
+                                                log,
+                                                "[Region] {}",
+                                                ltbox_core::i18n::tr("live_region_patched")
+                                                    .replace("{count}", &output.replacement_count.to_string())
+                                                    .replace("{path}", &output.vendor_boot.display().to_string())
+                                            );
+                                            ltbox_core::live!(
+                                                log,
+                                                "[Region] Repaired vendor_boot footer and rebuilt vbmeta: {}",
+                                                output.vbmeta.display()
+                                            );
+                                            region_pair = Some(output);
+                                        }
+                                        Ok(ltbox_patch::region::RegionBootChainBuild::Skipped {
+                                            source_region,
+                                            target,
+                                        }) => {
+                                            ltbox_core::live!(
+                                                log,
+                                                "[Region] {}",
+                                                ltbox_core::i18n::tr("live_region_source_target")
+                                                    .replace("{source}", &format!("{:?}", source_region))
+                                                    .replace("{target}", &format!("{:?}", target))
+                                            );
+                                            ltbox_core::live!(
+                                                log,
+                                                "[Region] {}",
+                                                ltbox_core::i18n::tr("live_region_source_matches_target")
+                                            );
+                                        }
+                                        Err(e) => return Err(format!("Region conversion failed: {e}")),
+                                    }
                                 } else {
                                     ltbox_core::live!(
                                         log,
@@ -5260,6 +5331,42 @@ impl App {
                                     &mut log,
                                 ) {
                                     return Err(format!("ARB flash {label}: {e}"));
+                                }
+                            }
+
+                            // Overwrite rawprogram's stock vendor_boot/vbmeta
+                            // with the final region-converted AVB-valid pair.
+                            // This must happen after rawprogram (and after any
+                            // ARB overlays) so stock XML entries cannot put the
+                            // unconverted ROW pair back on top.
+                            if let Some(output) = &region_pair {
+                                let overlays: [(&str, &std::path::Path); 2] = [
+                                    ("vendor_boot_a", output.vendor_boot.as_path()),
+                                    ("vbmeta_a", output.vbmeta.as_path()),
+                                ];
+                                for (label, image) in overlays {
+                                    let Some(lun) =
+                                        ltbox_core::partition_lun::lun_for_partition(label)
+                                    else {
+                                        return Err(format!(
+                                            "Region flash {label}: no hardcoded LUN"
+                                        ));
+                                    };
+                                    live!(
+                                        log,
+                                        "[Region] Flashing final {} ← {}",
+                                        label,
+                                        image.display()
+                                    );
+                                    if let Err(e) = session.flash_partition(
+                                        label,
+                                        image,
+                                        0,
+                                        lun,
+                                        &mut log,
+                                    ) {
+                                        return Err(format!("Region flash {label}: {e}"));
+                                    }
                                 }
                             }
 
@@ -7501,72 +7608,77 @@ impl App {
                                         );
                                     }
                                     AdvAction::RegionConvert => {
-                                        // Detect source region (PRC/ROW) by
-                                        // scanning for the IROW marker; the
-                                        // user-picked target comes from the
-                                        // wizard's region popup. Skip the
-                                        // patch when source already matches
-                                        // target so the user gets a clear
-                                        // signal instead of a no-op patched
-                                        // file with zero replacements.
                                         let Some(target_region) = adv_region_target else {
                                             return Err(
                                                 "No target region selected — pick PRC or ROW in the popup before starting"
                                                     .into(),
                                             );
                                         };
-                                        let data = match std::fs::read(input) {
-                                            Ok(b) => b,
-                                            Err(e) => return Err(format!("Read vendor_boot failed: {e}")),
-                                        };
-                                        let prc_dot = vec![0x2E, 0x50, 0x52, 0x43]; // ".PRC"
-                                        let prc_i = vec![0x49, 0x50, 0x52, 0x43];   // "IPRC"
-                                        let row_dot = vec![0x2E, 0x52, 0x4F, 0x57]; // ".ROW"
-                                        let row_i = vec![0x49, 0x52, 0x4F, 0x57];   // "IROW"
-                                        let has_row = data.windows(4).any(|w| w == row_i.as_slice());
-                                        let source_region = if has_row {
-                                            DeviceRegion::Row
-                                        } else {
-                                            DeviceRegion::Prc
-                                        };
-                                        ltbox_core::live!(
-                                            log,
-                                            "[Region] {}",
-                                            ltbox_core::i18n::tr("live_region_source_target")
-                                                .replace("{source}", &format!("{:?}", source_region))
-                                                .replace("{target}", &format!("{:?}", target_region))
-                                        );
-                                        if source_region == target_region {
-                                            ltbox_core::live!(
-                                                log,
-                                                "[Region] {}",
-                                                ltbox_core::i18n::tr("live_region_source_matches_target")
+                                        if input
+                                            .file_name()
+                                            .and_then(|s| s.to_str())
+                                            .map(|s| !s.eq_ignore_ascii_case("vendor_boot.img"))
+                                            .unwrap_or(true)
+                                        {
+                                            return Err(
+                                                "Region Convert expects vendor_boot.img; select the firmware folder's vendor_boot.img"
+                                                    .to_string(),
                                             );
-                                            return Ok(log);
                                         }
-                                        let target = match target_region {
-                                            DeviceRegion::Prc => ltbox_patch::region::RegionTarget::Prc,
-                                            DeviceRegion::Row => ltbox_patch::region::RegionTarget::Row,
-                                        };
-                                        let prc_patterns: Vec<(Vec<u8>, Vec<u8>)> = vec![
-                                            (prc_dot.clone(), row_dot.clone()),
-                                            (prc_i.clone(), row_i.clone()),
-                                        ];
-                                        let row_patterns: Vec<(Vec<u8>, Vec<u8>)> = vec![
-                                            (row_dot, prc_dot),
-                                            (row_i, prc_i),
-                                        ];
-                                        let stem = input.file_stem().map(|s| s.to_string_lossy().to_string()).unwrap_or_default();
-                                        let output = output_dir.join(format!("{stem}.patched.img"));
-                                        match ltbox_patch::region::patch_vendor_boot(input, &output, target, &prc_patterns, &row_patterns) {
-                                            Ok(n) => ltbox_core::live!(
-                                                log,
-                                                "[Region] {}",
-                                                ltbox_core::i18n::tr("live_region_patched")
-                                                    .replace("{count}", &n.to_string())
-                                                    .replace("{path}", &output.display().to_string())
-                                            ),
-                                            Err(e) => return Err(format!("Region patch failed: {e}")),
+                                        let firmware_dir = parent;
+                                        let sibling_vbmeta = firmware_dir.join("vbmeta.img");
+                                        if !sibling_vbmeta.is_file() {
+                                            return Err(format!(
+                                                "Region Convert requires vbmeta.img beside vendor_boot.img; missing {}",
+                                                sibling_vbmeta.display()
+                                            ));
+                                        }
+                                        let target = target_region.to_region_target();
+                                        match ltbox_patch::region::build_region_converted_boot_chain(
+                                            firmware_dir,
+                                            &output_dir,
+                                            target,
+                                            &ltbox_patch::region::RegionPatternSet::default(),
+                                        ) {
+                                            Ok(ltbox_patch::region::RegionBootChainBuild::Built(output)) => {
+                                                ltbox_core::live!(
+                                                    log,
+                                                    "[Region] {}",
+                                                    ltbox_core::i18n::tr("live_region_source_target")
+                                                        .replace("{source}", &format!("{:?}", output.source_region))
+                                                        .replace("{target}", &format!("{:?}", output.target))
+                                                );
+                                                ltbox_core::live!(
+                                                    log,
+                                                    "[Region] {}",
+                                                    ltbox_core::i18n::tr("live_region_patched")
+                                                        .replace("{count}", &output.replacement_count.to_string())
+                                                        .replace("{path}", &output.vendor_boot.display().to_string())
+                                                );
+                                                ltbox_core::live!(
+                                                    log,
+                                                    "[Region] Final vbmeta written: {}",
+                                                    output.vbmeta.display()
+                                                );
+                                            }
+                                            Ok(ltbox_patch::region::RegionBootChainBuild::Skipped {
+                                                source_region,
+                                                target,
+                                            }) => {
+                                                ltbox_core::live!(
+                                                    log,
+                                                    "[Region] {}",
+                                                    ltbox_core::i18n::tr("live_region_source_target")
+                                                        .replace("{source}", &format!("{:?}", source_region))
+                                                        .replace("{target}", &format!("{:?}", target))
+                                                );
+                                                ltbox_core::live!(
+                                                    log,
+                                                    "[Region] {}",
+                                                    ltbox_core::i18n::tr("live_region_source_matches_target")
+                                                );
+                                            }
+                                            Err(e) => return Err(format!("Region conversion failed: {e}")),
                                         }
                                     }
                                     AdvAction::PatchDevinfo => {
@@ -7848,6 +7960,17 @@ impl App {
                                                 return Err(format!("Rebuild vbmeta fallback resign failed: {e}"));
                                             }
                                         } else {
+                                            if chained.iter().any(|p| {
+                                                p.file_name()
+                                                    .and_then(|s| s.to_str())
+                                                    .map(|s| s.starts_with("vendor_boot"))
+                                                    .unwrap_or(false)
+                                            }) {
+                                                ltbox_core::live!(
+                                                    log,
+                                                    "[AVB] Warning: Rebuild vbmeta does not repair chained image footers; use Region Convert output for modified vendor_boot.img"
+                                                );
+                                            }
                                             let output = output_dir.join("vbmeta.rebuilt.img");
                                             let chained_refs: Vec<&std::path::Path> =
                                                 chained.iter().map(|p| p.as_path()).collect();

--- a/crates/ltbox-patch/src/avb.rs
+++ b/crates/ltbox-patch/src/avb.rs
@@ -307,12 +307,13 @@ mod tests {
             }
 
             let vendor_boot_info = extract_image_avb_info(&vendor_boot).unwrap();
+            let patterns = region::RegionPatternSet::default();
             let replaced = region::patch_vendor_boot(
                 &vendor_boot,
                 &patched_vendor_boot,
                 region::RegionTarget::Prc,
-                &[],
-                &[(b".ROW".to_vec(), b".PRC".to_vec())],
+                &patterns.prc_patterns,
+                &patterns.row_patterns,
             )
             .unwrap();
             assert!(replaced > 0);

--- a/crates/ltbox-patch/src/region.rs
+++ b/crates/ltbox-patch/src/region.rs
@@ -3,9 +3,10 @@
 //! Patches vendor_boot.img and devinfo/persist country codes.
 
 use fs_err as fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::avb::AvbImageInfo;
+use crate::{avb, key_map};
 use ltbox_core::{LtboxError, Result};
 use tracing::info;
 
@@ -67,6 +68,178 @@ pub enum RegionTarget {
     Row,
 }
 
+/// Vendor-boot region markers. `prc_patterns` are applied when the target is
+/// ROW (PRC -> ROW); `row_patterns` are applied when the target is PRC
+/// (ROW -> PRC).
+#[derive(Debug, Clone)]
+pub struct RegionPatternSet {
+    pub prc_patterns: Vec<(Vec<u8>, Vec<u8>)>,
+    pub row_patterns: Vec<(Vec<u8>, Vec<u8>)>,
+}
+
+impl Default for RegionPatternSet {
+    fn default() -> Self {
+        let prc_dot = b".PRC".to_vec();
+        let prc_i = b"IPRC".to_vec();
+        let row_dot = b".ROW".to_vec();
+        let row_i = b"IROW".to_vec();
+        Self {
+            prc_patterns: vec![
+                (prc_dot.clone(), row_dot.clone()),
+                (prc_i.clone(), row_i.clone()),
+            ],
+            row_patterns: vec![(row_dot, prc_dot), (row_i, prc_i)],
+        }
+    }
+}
+
+/// Region markers currently present in `vendor_boot.img`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectedRegion {
+    Prc,
+    Row,
+    Mixed,
+    Unknown,
+}
+
+impl DetectedRegion {
+    fn matches_target(self, target: RegionTarget) -> bool {
+        matches!(
+            (self, target),
+            (Self::Prc, RegionTarget::Prc) | (Self::Row, RegionTarget::Row)
+        )
+    }
+}
+
+/// Final region-converted boot chain written by
+/// [`build_region_converted_boot_chain`].
+#[derive(Debug, Clone)]
+pub struct RegionBootChainOutput {
+    pub vendor_boot: PathBuf,
+    pub vbmeta: PathBuf,
+    pub source_region: DetectedRegion,
+    pub target: RegionTarget,
+    pub replacement_count: usize,
+}
+
+/// Builder result. `Skipped` means the output folder was cleared and no files
+/// were emitted because the source already matched the requested target.
+#[derive(Debug, Clone)]
+pub enum RegionBootChainBuild {
+    Built(RegionBootChainOutput),
+    Skipped {
+        source_region: DetectedRegion,
+        target: RegionTarget,
+    },
+}
+
+/// Build the AVB-valid `vendor_boot.img` + `vbmeta.img` pair for region
+/// conversion.
+///
+/// This is the v3 equivalent of v2 `convert_region_images()`: copy
+/// `vendor_boot`, patch region bytes, re-apply the original `vendor_boot` AVB
+/// hash footer, then rebuild `vbmeta` with descriptors from the original
+/// vbmeta plus the patched chained image.
+pub fn build_region_converted_boot_chain(
+    firmware_dir: &Path,
+    output_dir: &Path,
+    target: RegionTarget,
+    patterns: &RegionPatternSet,
+) -> Result<RegionBootChainBuild> {
+    if output_dir.exists() {
+        fs::remove_dir_all(output_dir).map_err(|e| {
+            LtboxError::Patch(format!(
+                "Cannot clear region output {}: {e}",
+                output_dir.display()
+            ))
+        })?;
+    }
+    fs::create_dir_all(output_dir).map_err(|e| {
+        LtboxError::Patch(format!(
+            "Cannot create region output {}: {e}",
+            output_dir.display()
+        ))
+    })?;
+
+    let vendor_boot_src = firmware_dir.join("vendor_boot.img");
+    let vbmeta_src = firmware_dir.join("vbmeta.img");
+    if !vendor_boot_src.is_file() {
+        return Err(LtboxError::FileNotFound(format!(
+            "{}",
+            vendor_boot_src.display()
+        )));
+    }
+    if !vbmeta_src.is_file() {
+        return Err(LtboxError::FileNotFound(format!(
+            "{}",
+            vbmeta_src.display()
+        )));
+    }
+
+    let vendor_boot_data = fs::read(&vendor_boot_src).map_err(|e| {
+        LtboxError::Patch(format!("Cannot read {}: {e}", vendor_boot_src.display()))
+    })?;
+    let source_region = detect_region_in_data(&vendor_boot_data, patterns);
+    info!("Region source={source_region:?}, target={target:?}");
+    if source_region.matches_target(target) {
+        info!("Source already matches target; output folder left empty");
+        return Ok(RegionBootChainBuild::Skipped {
+            source_region,
+            target,
+        });
+    }
+
+    let vendor_boot_out = output_dir.join("vendor_boot.img");
+    let replacement_count = patch_vendor_boot(
+        &vendor_boot_src,
+        &vendor_boot_out,
+        target,
+        &patterns.prc_patterns,
+        &patterns.row_patterns,
+    )?;
+    info!("Region replacements: {replacement_count}");
+    if replacement_count == 0 {
+        let _ = fs::remove_file(&vendor_boot_out);
+        return Err(LtboxError::Patch(format!(
+            "No region patterns were replaced in {} (source={source_region:?}, target={target:?})",
+            vendor_boot_src.display()
+        )));
+    }
+
+    let vendor_boot_info = avb::extract_image_avb_info(&vendor_boot_src)?;
+    avb::add_hash_footer(&vendor_boot_out, &vendor_boot_info, None, None)?;
+    info!(
+        "Repaired vendor_boot AVB footer: {}",
+        vendor_boot_out.display()
+    );
+
+    let vbmeta_info = avb::extract_image_avb_info(&vbmeta_src)?;
+    let key_spec = key_map::key_spec_for_pubkey(vbmeta_info.public_key_sha1.as_deref())
+        .ok_or_else(|| {
+            LtboxError::Avb(format!(
+                "vbmeta signing key not recognized (pubkey {:?}); only bundled Lenovo testkeys are supported",
+                vbmeta_info.public_key_sha1
+            ))
+        })?;
+    let vbmeta_out = output_dir.join("vbmeta.img");
+    avb::rebuild_vbmeta_with_chained_images(
+        &vbmeta_out,
+        &vbmeta_src,
+        &[vendor_boot_out.as_path()],
+        key_spec,
+        Some(vbmeta_info.algorithm.as_str()),
+    )?;
+    info!("Rebuilt vbmeta chain: {}", vbmeta_out.display());
+
+    Ok(RegionBootChainBuild::Built(RegionBootChainOutput {
+        vendor_boot: vendor_boot_out,
+        vbmeta: vbmeta_out,
+        source_region,
+        target,
+        replacement_count,
+    }))
+}
+
 /// Patch vendor_boot.img for region conversion.
 /// Returns the number of pattern replacements made.
 pub fn patch_vendor_boot(
@@ -98,6 +271,26 @@ pub fn patch_vendor_boot(
         .map_err(|e| LtboxError::Patch(format!("Cannot write {}: {e}", output.display())))?;
 
     Ok(total_count)
+}
+
+fn detect_region_in_data(data: &[u8], patterns: &RegionPatternSet) -> DetectedRegion {
+    let prc_count: usize = patterns
+        .prc_patterns
+        .iter()
+        .map(|(from, _)| count_occurrences(data, from))
+        .sum();
+    let row_count: usize = patterns
+        .row_patterns
+        .iter()
+        .map(|(from, _)| count_occurrences(data, from))
+        .sum();
+
+    match (prc_count > 0, row_count > 0) {
+        (true, false) => DetectedRegion::Prc,
+        (false, true) => DetectedRegion::Row,
+        (true, true) => DetectedRegion::Mixed,
+        (false, false) => DetectedRegion::Unknown,
+    }
 }
 
 /// Detect country code in a binary image (devinfo/persist).
@@ -242,6 +435,27 @@ mod tests {
     }
 
     #[test]
+    fn default_patterns_detect_region() {
+        let patterns = RegionPatternSet::default();
+        assert_eq!(
+            detect_region_in_data(b"abc IPRC def", &patterns),
+            DetectedRegion::Prc
+        );
+        assert_eq!(
+            detect_region_in_data(b"abc IROW def", &patterns),
+            DetectedRegion::Row
+        );
+        assert_eq!(
+            detect_region_in_data(b".PRC and .ROW", &patterns),
+            DetectedRegion::Mixed
+        );
+        assert_eq!(
+            detect_region_in_data(b"no marker", &patterns),
+            DetectedRegion::Unknown
+        );
+    }
+
+    #[test]
     fn detect_country_in_buffer() {
         let data = b"\x00\x00CNXX\x00\x00";
         let dir = tempfile::tempdir().unwrap();
@@ -250,5 +464,52 @@ mod tests {
 
         let code = detect_country_code(&path, &["CN", "KR", "US"]).unwrap();
         assert_eq!(code, Some("CN".to_string()));
+    }
+
+    #[test]
+    fn real_firmware_builds_region_boot_chain_when_available() {
+        let Some(dir) = std::env::var_os("LTBOX_REAL_FIRMWARE_DIR") else {
+            return;
+        };
+        let dir = PathBuf::from(dir);
+        let vendor_boot_src = dir.join("vendor_boot.img");
+        let vbmeta_src = dir.join("vbmeta.img");
+        if !vendor_boot_src.is_file() || !vbmeta_src.is_file() {
+            return;
+        }
+
+        let patterns = RegionPatternSet::default();
+        let data = fs::read(&vendor_boot_src).unwrap();
+        if detect_region_in_data(&data, &patterns) != DetectedRegion::Row {
+            return;
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let output_dir = tmp.path().join("region");
+        fs::create_dir_all(&output_dir).unwrap();
+        fs::write(output_dir.join("vendor_boot.patched.img"), b"stale").unwrap();
+
+        let built =
+            build_region_converted_boot_chain(&dir, &output_dir, RegionTarget::Prc, &patterns)
+                .unwrap();
+
+        let RegionBootChainBuild::Built(output) = built else {
+            panic!("ROW firmware should build a PRC output pair");
+        };
+        assert!(output.vendor_boot.is_file());
+        assert!(output.vbmeta.is_file());
+        assert!(output.replacement_count > 0);
+        assert!(!output_dir.join("vendor_boot.patched.img").exists());
+
+        let source_vendor_boot = fs::read(&vendor_boot_src).unwrap();
+        let output_vendor_boot = fs::read(&output.vendor_boot).unwrap();
+        assert_ne!(source_vendor_boot, output_vendor_boot);
+
+        assert_eq!(
+            fs::metadata(&output.vbmeta).unwrap().len(),
+            fs::metadata(&vbmeta_src).unwrap().len()
+        );
+        let report = avb::image_info_report(&[output.vbmeta]).unwrap();
+        assert!(report.contains("vendor_boot"));
     }
 }


### PR DESCRIPTION
This fixes the region-conversion flow so it builds and flashes an AVB-valid `vendor_boot.img` + `vbmeta.img` pair, matching the behavior of the v2.5.x pipeline.

Previously, v3 could complete a full ROW flash on a PRC/CN TB321FU device while still leaving the stock ROW `vendor_boot` + `vbmeta` boot-chain in place. On my device this resulted in Lenovo’s hardware/region lock message:

> The current system is not compatible with hardware. The device will power off automatically.

### Test case

Tested on Lenovo Legion Y700 Gen 3 / TB321FU:

- Hardware: TB321FU PRC/CN variant
- Original firmware: `TB321FU_CN_OPEN_USER_Q00011.0_V_ZUI_17.0.10.308_ST_251030`
- Target firmware: `TB321FU_ROW_OPEN_USER_Q00002.0_W_ZUI_17.5.10.031_ST_251125`
- Bootloader: locked
- Flash path: LTBox v3 beta 2 EDL flow
- Country code selected: `AT`

The v3 full flash successfully wrote the ROW firmware, rollback-patched images, and country-code changes:

- `boot_a` rollback-patched
- `vbmeta_system_a` rollback-patched
- `devinfo` patched from `CN` to `AT`
- `persist` patched from `CN` to `AT`

However, after reboot the device still hit the Lenovo region-lock screen. The output folders contained rollback and country-code artifacts, but no final region-converted `vendor_boot` / rebuilt `vbmeta` pair from the full flash flow.

### Probable Cause

For this device, PRC-hardware → ROW-firmware conversion appears to require a complete boot-chain pair:

- `vendor_boot` region markers patched for the hardware compatibility check
- `vendor_boot` AVB hash footer repaired after patching
- `vbmeta` rebuilt so the locked bootloader accepts the modified `vendor_boot`

A manual experiment confirmed the sequence:

1. Stock ROW `vendor_boot` + stock ROW `vbmeta` → Lenovo region-lock screen.
2. Raw byte-patched `vendor_boot` with incomplete/mismatched `vbmeta` → AVB corruption screen.
3. Footer-repaired patched `vendor_boot` + rebuilt `vbmeta` → booted successfully to ROW ZUI.

The v2.5.x `convert_region_images()` pipeline handled this as one combined operation: patch `vendor_boot`, apply the AVB footer using the original metadata, rebuild `vbmeta`, and output the final pair. In v3, these pieces existed separately, but the region conversion path did not consistently produce and flash the final AVB-valid pair.

### Changes

This adds a boot-chain builder that:

- clears stale region output before generating new files,
- reads `vendor_boot.img` and `vbmeta.img` from the firmware folder,
- detects the current `vendor_boot` region markers,
- patches to the requested target region,
- re-applies the original `vendor_boot` AVB footer,
- rebuilds `vbmeta.img` using the patched `vendor_boot`,
- returns final output paths for `vendor_boot.img` and `vbmeta.img`.

Full flash flow now flashes this generated pair after the rawprogram XML phase, so stock XML entries cannot overwrite the converted boot chain.

Advanced → Region Convert now expects a `vendor_boot.img` with sibling `vbmeta.img` and outputs a complete final pair instead of only a raw `vendor_boot.patched.img`.

Advanced → Rebuild vbmeta now warns that rebuilding vbmeta alone does not repair modified chained-image footers, so modified `vendor_boot` images should come from the Region Convert output.

### Validation

Tested locally on TB321FU / Y700 Gen 3:

- Before this patch: full ROW flash completed, but device booted to Lenovo hardware/region lock screen.
- After this patch: generated and flashed the final `vendor_boot_a` + `vbmeta_a` pair, and the device booted successfully to ROW ZUI.

### Notes

This change is limited to region conversion and AVB-valid boot-chain generation. I tested it on one TB321FU device and cannot verify behavior across all supported models or firmware builds.